### PR TITLE
Remove go fmt & go test from reflex.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,12 @@ RUN echo "reflex -c /_tools/reflex.conf; sh" >> /_tools/up.sh
 RUN echo "-sg '*.go' /_tools/build.sh" >> /_tools/reflex.conf
 
 RUN echo "#!/bin/sh" >> /_tools/build.sh
-RUN echo "cd $SRCPATH && go fmt && go test && go build -o /appbin && rm -rf /tmp/*" >> /_tools/build.sh
+RUN echo "cd $SRCPATH && go build -o /appbin && rm -rf /tmp/*" >> /_tools/build.sh
 RUN echo "/appbin" >> /_tools/build.sh
 
-# Install Git
+# Install tools
 RUN apk add --no-cache \
 	git \
-# Install Vim
 	vim \
 	curl
 


### PR DESCRIPTION
Why:
Those commands should be invoked
through command line or vim (using vim-go)

This change addresses the need by:
Remove the commands from the config file